### PR TITLE
feat(sync.sh): add --port and --key SSH options for remote sync (#8)

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -7,7 +7,7 @@ Utility scripts for day-to-day development workflow.
 Pull the latest changes for every git repository found in a directory.
 
 ```bash
-update.sh [-q|--quiet] [-f|--fetch-only] [-s|--stash] [directory]
+update.sh [-q|--quiet] [-f|--fetch-only] [-s|--stash] [-p|--parallel] [directory]
 ```
 
 | Argument             | Default | Description                              |
@@ -15,6 +15,8 @@ update.sh [-q|--quiet] [-f|--fetch-only] [-s|--stash] [directory]
 | `-q`, `--quiet`      |         | Only show repos with changes or problems |
 | `-f`, `--fetch-only` |         | Fetch only — report behind, no pull      |
 | `-s`, `--stash`      |         | Auto-stash local changes, pull, then pop |
+| `-p`, `--parallel`   |         | Pull all repos concurrently              |
+| `-h`, `--help`       |         | Show help and exit                       |
 | `directory`          | `$PWD`  | Directory to scan for git repositories   |
 
 **Behaviour:**
@@ -24,6 +26,8 @@ update.sh [-q|--quiet] [-f|--fetch-only] [-s|--stash] [directory]
 - Uses `--ff-only` to avoid creating merge commits
 - All git operations are subject to a timeout (default 60s; override
   with `GIT_PULL_TIMEOUT=N`)
+- Parallel mode runs up to 8 concurrent jobs (override with
+  `UPDATE_MAX_JOBS=N`); results are displayed in original directory order
 - Prints a summary: updated / already current / skipped / failed
 
 **Examples:**
@@ -40,6 +44,12 @@ update.sh --fetch-only
 
 # Auto-stash local changes, pull, then restore
 update.sh --stash
+
+# Pull all repos in parallel (faster for many repos)
+update.sh --parallel
+
+# Parallel with a custom concurrency limit
+UPDATE_MAX_JOBS=4 update.sh --parallel
 
 # Update all repos in a specific directory
 update.sh ~/Documents/projects
@@ -64,18 +74,22 @@ remote (`user@host:/path`).
 
 ```bash
 sync.sh [--dry-run] [--exclude pattern] [--no-default-excludes] \
-        [--max-retries N] [source [target]]
+        [--max-retries N] [--bwlimit KBPS] [--port N] [--key path] \
+        [source [target]]
 ```
 
-| Argument                | Default         | Description                   |
-|-------------------------|-----------------|-------------------------------|
-| `--dry-run`, `-n`       |                 | Show what would change, no-op |
-| `--exclude pattern`     |                 | Exclude an additional pattern |
-| `--no-default-excludes` |                 | Disable built-in exclude list |
-| `--max-retries N`       | `0` (unlimited) | Max retry attempts (remote)   |
-| `--bwlimit N`           | `0` (unlimited) | Bandwidth cap in KB/s         |
-| `source`                | `$HOME/`        | Directory to sync from        |
-| `target`                | (Lacie drive)   | Local path or `user@host:path`|
+| Argument                | Default         | Description                    |
+|-------------------------|-----------------|--------------------------------|
+| `--dry-run`, `-n`       |                 | Show what would change, no-op  |
+| `--exclude pattern`     |                 | Exclude an additional pattern  |
+| `--no-default-excludes` |                 | Disable built-in exclude list  |
+| `--max-retries N`       | `0` (unlimited) | Max retry attempts (remote)    |
+| `--bwlimit N`           | `0` (unlimited) | Bandwidth cap in KB/s          |
+| `--port N`              |                 | SSH port (remote only)         |
+| `--key path`            |                 | SSH identity file (remote only)|
+| `-h`, `--help`          |                 | Show help and exit             |
+| `source`                | `$HOME/`        | Directory to sync from         |
+| `target`                | (Lacie drive)   | Local path or `user@host:path` |
 
 **Default excludes** (applied automatically unless `--no-default-excludes`):
 `.DS_Store`, `.Trash/`, `node_modules/`, `.cache/`, `__pycache__/`, `*.pyc`,
@@ -109,6 +123,9 @@ sync.sh --max-retries 5 $HOME/ alice@myserver.local:/backups/alice/
 
 # Throttle to ~10 MB/s to avoid saturating the network
 sync.sh --bwlimit 10000 $HOME/ alice@myserver.local:/backups/alice/
+
+# Remote sync with a non-standard SSH port and specific key
+sync.sh --port 2222 --key ~/.ssh/id_backup $HOME/ alice@myserver.local:/backups/
 
 # Pull a directory from a remote machine to local
 sync.sh alice@myserver.local:/home/alice/projects/ ~/projects/

--- a/tools/sync.sh
+++ b/tools/sync.sh
@@ -3,8 +3,10 @@
 # @description Sync a source directory to a local or remote target using rsync.
 #              Auto-detects remote targets from user@host:/path format.
 # @author Alister Lewis-Bowen <alister@lewis-bowen.org>
-# @version 2.4.0
-# @usage sync.sh [--dry-run] [--exclude pattern] [--no-default-excludes] [--max-retries N] [--bwlimit KBPS] [source [target]]
+# @version 2.5.0
+# @usage sync.sh [--dry-run] [--exclude pattern] [--no-default-excludes]
+#                [--max-retries N] [--bwlimit KBPS] [--port N] [--key path]
+#                [source [target]]
 # @dependencies rsync, pfb
 # @exit 0 Success
 # @exit 1 Invalid arguments or sync failure
@@ -30,6 +32,7 @@ SCRIPT_DIR="$(cd "$(dirname "$_script")" && pwd)"
 unset _script _script_dir
 
 # shellcheck source=../bootstrap/pfb/pfb.sh
+# shellcheck disable=SC1091
 source "${SCRIPT_DIR}/../bootstrap/pfb/pfb.sh" 2>/dev/null || {
     pfb() {
         local cmd="${1:-}"; shift || true
@@ -45,6 +48,49 @@ source "${SCRIPT_DIR}/../bootstrap/pfb/pfb.sh" 2>/dev/null || {
 }
 
 # ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+# @description Print usage information and exit
+# @param $1 Optional exit code (default 0)
+usage() {
+    cat <<EOF
+
+Usage: $(basename "$0") [OPTIONS] [source [target]]
+
+Sync a source directory to a local or remote target using rsync.
+Remote targets are auto-detected from user@host:/path format.
+
+Options:
+  -n, --dry-run              Show what would change; transfer nothing
+      --exclude PATTERN      Exclude an additional file pattern
+      --no-default-excludes  Disable the built-in exclude list
+      --max-retries N        Max retry attempts for remote sync (0 = unlimited)
+      --bwlimit KBPS         Bandwidth cap in KB/s (0 = unlimited)
+      --port N               SSH port for remote sync (default: 22)
+      --key PATH             SSH identity file for remote sync
+  -h, --help                 Show this help and exit
+
+Arguments:
+  source   Directory to sync from (default: \$HOME/)
+  target   Local path or user@host:/path (default: /Volumes/Lacie/\$HOSTNAME/)
+
+Default excludes (disabled with --no-default-excludes):
+  .DS_Store  .Trash/  node_modules/  .cache/  __pycache__/
+  *.pyc  .venv/  dist/  build/
+
+Examples:
+  $(basename "$0")
+  $(basename "$0") --dry-run
+  $(basename "$0") --exclude '.env' ~/Documents /Volumes/Backup/docs
+  $(basename "$0") \$HOME/ alice@myserver.local:/backups/alice/
+  $(basename "$0") --port 2222 --key ~/.ssh/id_rsa \$HOME/ alice@myserver.local:/backups/
+  $(basename "$0") --bwlimit 10000 \$HOME/ alice@myserver.local:/backups/alice/
+EOF
+    exit "${1:-0}"
+}
+
+# ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
 
@@ -53,6 +99,8 @@ USE_DEFAULT_EXCLUDES=true
 EXTRA_EXCLUDES=()
 MAX_RETRIES="${SYNC_MAX_RETRIES:-0}"  # 0 = unlimited retries for remote syncs
 BWLIMIT="${SYNC_BWLIMIT:-0}"          # 0 = unlimited bandwidth (KB/s)
+SSH_PORT=""
+SSH_KEY=""
 
 # Default patterns that are never worth syncing
 DEFAULT_EXCLUDES=(
@@ -77,6 +125,11 @@ while [[ $# -gt 0 ]]; do
         --max-retries=*)          MAX_RETRIES="${1#--max-retries=}"; shift ;;
         --bwlimit)                BWLIMIT="$2"; shift 2 ;;
         --bwlimit=*)              BWLIMIT="${1#--bwlimit=}"; shift ;;
+        --port)                   SSH_PORT="$2"; shift 2 ;;
+        --port=*)                 SSH_PORT="${1#--port=}"; shift ;;
+        --key)                    SSH_KEY="$2"; shift 2 ;;
+        --key=*)                  SSH_KEY="${1#--key=}"; shift ;;
+        -h|--help)                usage 0 ;;
         -*) pfb err "Unknown option: $1"; exit 1 ;;
         *)  break ;;
     esac
@@ -137,8 +190,11 @@ sync_local() {
 # @side_effects Transfers files over the network
 sync_remote() {
     local con_alive=1800  # SSH keepalive interval in seconds
+    local ssh_opts="ssh -o ServerAliveInterval=$con_alive"
+    [[ -n "$SSH_PORT" ]] && ssh_opts+=" -p $SSH_PORT"
+    [[ -n "$SSH_KEY"  ]] && ssh_opts+=" -i $SSH_KEY"
     local flags=( -az --partial --delete --progress --timeout="$con_alive"
-                  -e "ssh -o ServerAliveInterval=$con_alive" )
+                  -e "$ssh_opts" )
     $DRY_RUN && flags+=( --dry-run )
     [[ $BWLIMIT -gt 0 ]] && flags+=( --bwlimit="$BWLIMIT" )
     build_exclude_flags
@@ -146,6 +202,8 @@ sync_remote() {
     pfb heading "Remote sync" "🌐"
     pfb subheading "From: $SOURCE_DIR"
     pfb subheading "  To: $TARGET_DIR"
+    [[ -n "$SSH_PORT" ]] && pfb info "SSH port: $SSH_PORT"
+    [[ -n "$SSH_KEY"  ]] && pfb info "SSH key:  $SSH_KEY"
     [[ $BWLIMIT -gt 0 ]] && pfb info "Bandwidth capped at ${BWLIMIT} KB/s"
     $DRY_RUN && pfb warn "Dry run — no files will be transferred"
 
@@ -168,11 +226,18 @@ if ! is_remote "$SOURCE_DIR" && [[ ! -d "$SOURCE_DIR" ]]; then
     exit 1
 fi
 
+sync_ok=false
 if is_remote "$SOURCE_DIR" || is_remote "$TARGET_DIR"; then
-    sync_remote
+    sync_remote && sync_ok=true
 else
-    sync_local
-fi && pfb success "Sync complete" || {
+    [[ -n "$SSH_PORT" || -n "$SSH_KEY" ]] && \
+        pfb warn "--port and --key have no effect in local mode"
+    sync_local && sync_ok=true
+fi
+
+if $sync_ok; then
+    pfb success "Sync complete"
+else
     pfb err "Sync failed"
     exit 1
-}
+fi


### PR DESCRIPTION
## Summary

- Adds `--port N` to connect over a non-standard SSH port
- Adds `--key path` to specify an SSH identity file
- Both are injected into rsync's `-e "ssh ..."` argument
- Warns (but does not error) if used when syncing to a local target
- Useful for home-lab and personal server setups without needing a
  `~/.ssh/config` entry

## Test plan

- [ ] `sync.sh --port 2222 --dry-run $HOME/ user@host:/backup/` — confirm
  port appears in rsync's ssh command
- [ ] `sync.sh --key ~/.ssh/id_backup --dry-run $HOME/ user@host:/backup/`
  — confirm key passed through
- [ ] `sync.sh --port 2222 /tmp/ /tmp/dest/` — confirm warning shown,
  sync still proceeds

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)