### PR TITLE
refactor(shell): replace hstr with fzf for history search

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Tested on macOS Tahoe and Debian-based Linux (Bookworm/Trixie), including Raspbe
 - 📦 Node version management (nvm)
 - ⭐ Starship prompt with custom themes
 - 📁 Directory jumper (z.sh)
-- 🔍 Enhanced history search (hstr)
+- 🔍 History search via fzf (Ctrl-R)
 - 🎨 Syntax highlighting (bat)
 - 🔄 Automatic daily package updates
 - 🤖 AI tools: Claude Code, Gemini CLI, and Codex CLI (with shared coding standards)
@@ -84,7 +84,7 @@ git clone --recursive https://github.com/ali5ter/carrybag-lite.git ~/src/carryba
 
 - `git`, `vim`, `shellcheck`, `watch`
 - `jq`, `yq`, `bat`, `tree`, `fzf`, `figlet`
-- `starship` (prompt), `hstr` (history), `z` (directory jumper)
+- `starship` (prompt), `fzf` (history + fuzzy search), `z` (directory jumper)
 - Nerd Fonts, Claude Code
 
 **macOS only:**

--- a/bash_profile
+++ b/bash_profile
@@ -17,6 +17,10 @@ shopt -s histappend     # append history instead of overwriting it
 shopt -s cdspell        # corrected minor spelling errors during cd
 # @ref https://www.linuxjournal.com/content/using-bash-history-more-efficiently-histcontrol
 HISTCONTROL=ignoreboth
+export HISTFILESIZE=10000        # increase history file size (default is 500)
+export HISTSIZE=${HISTFILESIZE}  # increase history size (default is 500)
+# Synchronize history across sessions
+export PROMPT_COMMAND="history -a; history -n; ${PROMPT_COMMAND}"
 CDATE=$(date '+%Y%m%d')
 # Enable ls colors
 export CLICOLOR=1
@@ -197,22 +201,6 @@ else
     fi
 fi
 
-# History manager
-# @ref https://github.com/dvorka/hstr/blob/master/CONFIGURATION.md
-type hstr >/dev/null 2>&1 && {
-    alias hh=hstr                    # hh to be alias for hstr
-    export HSTR_CONFIG=hicolor       # get more colors
-    shopt -s histappend              # append new history items to .bash_history
-    export HISTCONTROL=ignorespace   # leading space hides commands from history
-    export HISTFILESIZE=10000        # increase history file size (default is 500)
-    export HISTSIZE=${HISTFILESIZE}  # increase history size (default is 500)
-    # ensure synchronization between bash memory and history file
-    export PROMPT_COMMAND="history -a; history -n; ${PROMPT_COMMAND}"
-    # if this is interactive shell, then bind hstr to Ctrl-r (for Vi mode check doc)
-    if [[ $- =~ .*i.* ]]; then bind '"\C-r": "\C-a hstr -- \C-j"'; fi
-    # if this is interactive shell, then bind 'kill last command' to Ctrl-x k
-    if [[ $- =~ .*i.* ]]; then bind '"\C-xk": "\C-a hstr -k \C-j"'; fi
-}
 
 # Functions
 

--- a/bootstrap/install.sh
+++ b/bootstrap/install.sh
@@ -381,10 +381,6 @@ disabled = true
 END_OF_STARSHIP_CONFIG
 }
 
-install_hstr() {
-    # @ref https://github.com/dvorka/hstr
-    install hstr
-}
 
 config_ssh() {
     [[ -f ~/.ssh/config ]] || { 
@@ -482,10 +478,6 @@ main() {
     pfb info "Installing starship prompt..."
     install_starship
     pfb success "Starship prompt installed!"
-    echo
-    pfb info "Installing hstr..."
-    install_hstr
-    pfb success "hstr installed!"
     echo
     echo; local default='N'; read -r -p "Install Docker? [y/N]: " response
     pfb answer ${response:-$default}


### PR DESCRIPTION
## Summary

- `fzf` already provided Ctrl-R history search via `eval "$(fzf --bash)"` — `hstr` was redundant and its own Ctrl-R binding was silently overriding fzf's
- Removes `hstr` as an installed dependency entirely
- Promotes the useful settings from the hstr block (`HISTFILESIZE`, `HISTSIZE`, `PROMPT_COMMAND` session sync) to the general shell options section so they are always active
- Updates README features list and tool inventory

## Test plan

- [ ] Source `bash_profile` and verify Ctrl-R opens fzf history search
- [ ] Confirm `HISTFILESIZE` and `HISTSIZE` are set to 10000 in a new shell
- [ ] Confirm history is synced across sessions via `PROMPT_COMMAND`
- [ ] Run `bash -n bash_profile` and `bash -n bootstrap/install.sh` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)