### PR TITLE
fix(bootstrap): remove duplicate claude-code install on macOS

### DIFF
--- a/bootstrap/install.sh
+++ b/bootstrap/install.sh
@@ -87,7 +87,7 @@ bootstrap_mac() {
     install ncdu # disk management
     install nmap # network tools
     install wakeonlan # wake-on-lan
-    install claude-code gemini-cli codex # AI tools
+    install gemini-cli codex # AI tools (claude-code installed via install_claude_code)
     install figlet # banner generation
 
     # GUI applications


### PR DESCRIPTION
## Problem

Closes #21

`bootstrap_mac()` included `claude-code` in its main package install line, but `main()` also calls `install_claude_code()` which installs it again. This meant claude-code was being installed twice on every macOS bootstrap run.

## Fix

Remove `claude-code` from the `bootstrap_mac()` line. `install_claude_code()` already handles installation on both macOS and Linux and is the right single owner of this.

## Test plan

- [ ] Run bootstrap on macOS, confirm claude-code is installed once via `install_claude_code()`
- [ ] Confirm `gemini-cli` and `codex` still install correctly via `bootstrap_mac()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)