### PR TITLE
docs: add GitHub attribution footer and CLAUDE.md gitignore note

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -254,7 +254,7 @@ project/
 When creating any GitHub content — PRs, issues, or comments — end with:
 
 ```text
-🤖 Generated with [SOURCE](URL) on behalf of Alister (https://github.com/ali5ter)
+🤖 Generated with [SOURCE](URL) on behalf of [Alister](https://github.com/ali5ter)
 ```
 
 Where SOURCE is:

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -208,7 +208,10 @@ use their name. Ask if you don't know their name.
 Every project should have:
 
 - **README.md** - Overview, installation, usage
-- **CLAUDE.md** - AI context file (project status, decisions, quick resume)
+- **CLAUDE.md** - AI context file (project status, decisions, quick resume). Intentionally gitignored — never
+  committed to the remote repo. Each project's `CLAUDE.md` is untracked locally and managed separately in the private
+  [ai-context](https://github.com/ali5ter/ai-context) repo. This keeps project-level AI context private and out of
+  public repos while still being available to Claude Code during local development.
 - **.env.template** - Configuration template for users (if needed)
 - **.gitignore** - Proper exclusions for secrets and generated files
 - **.markdownlint.json** - Markdown linting configuration
@@ -245,6 +248,20 @@ project/
 - [ ] Configuration uses templates, not hardcoded values
 - [ ] Error messages are actionable
 - [ ] No secrets in version control
+
+## GitHub Attribution
+
+When creating any GitHub content — PRs, issues, or comments — end with:
+
+```text
+🤖 Generated with [SOURCE](URL) on behalf of Alister (https://github.com/ali5ter)
+```
+
+Where SOURCE is:
+
+- The invoking Claude Code skill or agent with its repo URL, if a named skill or agent was responsible.
+  Example: `[claude-workflow-skills:audit-standards](https://github.com/ali5ter/claude-workflow-skills)`
+- `[Claude Code](https://claude.com/claude-code)` for general Claude Code work with no specific skill invoked.
 
 ## Anti-Patterns to Avoid
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -201,6 +201,30 @@ use their name. Ask if you don't know their name.
 - Security: validate at system boundaries, never trust external input
 - Logging: structured where possible, appropriate levels
 
+## GitHub Repository Standards
+
+Every GitHub repo should be set up with:
+
+**Access control:**
+
+- Branch protection on the default branch requiring a PR before merging — Alister reviews and decides whether to
+  merge manually or ask Claude to auto-merge.
+
+**Discoverability:**
+
+- A concise description set on the repo.
+- Appropriate topics applied to the repo for discoverability.
+
+**Minimum files:**
+
+- `LICENSE` — MIT License with copyright holder Alister Lewis-Bowen.
+- `README.md` — Overview, installation, and usage.
+
+**Release hygiene:**
+
+- Changes promoted via annotated git tags and GitHub Releases with generated release notes.
+- Tags follow semver (`v1.2.3`).
+
 ## Project Organization
 
 ### Standard Files


### PR DESCRIPTION
## Summary

- Adds **GitHub Attribution** section: all PRs, issues, and comments created by Claude Code should end with a
  `🤖 Generated with [SOURCE](URL) on behalf of Alister` footer, using the invoking skill/agent URL where
  applicable, falling back to the general Claude Code URL
- Updates **Standard Files** entry for `CLAUDE.md` to document the intentional gitignore design — project-level
  AI context files are kept untracked locally and managed in the private
  [ai-context](https://github.com/ali5ter/ai-context) repo

## Test plan

- [x] Review attribution section wording and examples
- [x] Confirm CLAUDE.md note accurately reflects the ai-context repo pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of Alister (https://github.com/ali5ter)